### PR TITLE
Refactor hash command check in chat.js

### DIFF
--- a/apps/chat.js
+++ b/apps/chat.js
@@ -120,11 +120,14 @@ export class Chat extends plugin {
             if (pattern.test(rawMsg)) return false
         }
 
-        // 检查#命令
+        // 检查#命令（排除触发前缀）
         const allowHashCmds = triggerCfg.allowHashCommands === true
         if (!allowHashCmds && /^#\S/.test(rawMsg)) {
             const cleanedForCheck = this.cleanAtBot(rawMsg)
-            if (/^#\S/.test(cleanedForCheck.trim())) return false
+            // 如果是触发前缀消息（如 #chat），不拦截
+            const prefixes = triggerCfg.prefixes || []
+            const isTriggerPrefix = prefixes.some(p => p && cleanedForCheck.startsWith(p))
+            if (!isTriggerPrefix && /^#\S/.test(cleanedForCheck.trim())) return false
         }
 
         // 检查访问权限


### PR DESCRIPTION
修复`#` 命令拦截逻辑存在缺陷。这条逻辑本意是拦截系统命令（如 `#结束对话`、`#清除记忆`），但同时也拦截了以 `#chat` 开头的前缀触发消息，导致发送 `#chat xxx` 时 Bot 不响应。 __修复方案__： 在拦截前检查消息是否匹配触发前缀（如 `#chat`），只有不是触发前缀的`#` 命令才被拦截：

## 变更类型
<!-- 请勾选适用的选项 -->
- [ ] 🐛 Bug 修复 (fix)

## 变更描述
修复 `#` 命令拦截逻辑存在缺陷。逻辑本意是拦截系统命令（如 `#结束对话`、`#清除记忆`），但同时也拦截了以 `#chat` 开头的前缀触发消息，导致发送 `#chat xxx` 时 Bot 不响应。

修复方案__： 在拦截前检查消息是否匹配触发前缀（如 `#chat`），只有不是触发前缀 `#` 命令才被拦截：

